### PR TITLE
tiny little simple minor fix for Safari to not ignore mp4 files while using the filepicker menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <body>
   <div id="background" class="full">
     refresh if visible (javascript didn't load)
-    <input type="file" id="filepicker" multiple accept="video/*,image/*"/>
+    <input type="file" id="filepicker" multiple accept="video/mp4,video/x-m4v,video/*,image/*"/>
   </div>
   <div id="foreground" class="full">
     <div id="cursor_preview">


### PR DESCRIPTION
changed attributes 'accept' of 'filepicker' input on index.html to "video/mp4,video/x-m4v,video/*,image/*" instead of "video/*,image/*"